### PR TITLE
If :underline is unspecified, highlight the line using :background

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ for a few built-in elements.
 
 ![screenshot](https://emacsair.me/assets/readme/moody.png)
 
-* Make sure that the face `mode-line` does not set `:box` and that
-  it sets `:underline` and `:overline` to the same color.  That
-  color should be different from the `:background` colors of both
-  `mode-line` and `default`.  Do the same for `mode-line-inactive`.
-  The line colors of `mode-line` and `mode-line-inactive` do not
+* Make sure that the face `mode-line` does not set `:box` and
+  that `:underline` and `:overline` are the same color or are
+  both `undefined`.  If defined, then the line color should be
+  different from the `:background` colors of both `mode-line`
+  and `default`.  Do the same for `mode-line-inactive`.  The
+  line colors of `mode-line` and `mode-line-inactive` do not
   have to be identical.  For example:
 
   ```lisp

--- a/moody.el
+++ b/moody.el
@@ -40,11 +40,12 @@
 
 ;; Usage:
 
-;; * Make sure that the face `mode-line' does not set `:box' and that
-;;   it sets `:underline' and `:overline' to the same color.  That
-;;   color should be different from the `:background' colors of both
-;;   `mode-line' and `default'.  Do the same for `mode-line-inactive'.
-;;   The line colors of `mode-line' and `mode-line-inactive' do not
+;; * Make sure that the face `mode-line' does not set `:box' and
+;;   that `:underline' and `:overline' are the same color or are
+;;   both `undefined'.  If defined, then the line color should be
+;;   different from the `:background' colors of both `mode-line'
+;;   and `default'.  Do the same for `mode-line-inactive'.  The
+;;   line colors of `mode-line' and `mode-line-inactive' do not
 ;;   have to be identical.  For example:
 ;;
 ;;     (use-package solarized-theme

--- a/moody.el
+++ b/moody.el
@@ -141,6 +141,7 @@ not specified, then faces based on `default', `mode-line' and
                   (or face-inactive 'mode-line-inactive)))
          (outer (face-attribute base :background))
          (line  (face-attribute base :underline))
+         (line  (if (eq line 'unspecified) outer line))
          (inner (if (eq type 'ribbon)
                     (face-attribute base :underline)
                   (face-attribute 'default :background)))


### PR DESCRIPTION
This PR tries to improve the colouring when the theme doesn't define `:underline` attribute for `mode-line` and/or `mode-line-inactive`.

Hopefully, as a result of this PR, the only requirement for using moody out of the box will be: `:box` must not be specified for the mode-line(-inactive) faces

Before this PR, this is how `eclipse` and `twilight-bright` looked (neither of them defines `:underline`):

<img width="1297" alt="screen shot 2018-03-07 at 09 30 30" src="https://user-images.githubusercontent.com/1532071/37079506-86b8b15e-21eb-11e8-99f7-7b046775c2d5.png">
<img width="1299" alt="screen shot 2018-03-07 at 09 29 59" src="https://user-images.githubusercontent.com/1532071/37079508-86f90812-21eb-11e8-9b8c-717619d2a5b4.png">


After this PR:

<img width="1296" alt="screen shot 2018-03-07 at 09 28 17" src="https://user-images.githubusercontent.com/1532071/37079513-8bd3c458-21eb-11e8-9117-ff19e1b1f056.png">
<img width="1300" alt="screen shot 2018-03-07 at 09 27 58" src="https://user-images.githubusercontent.com/1532071/37079514-8bfac080-21eb-11e8-9086-b34076b62dfa.png">


Please let me know if the PR can be improved.