### PR TITLE
Detect switched frame by `{make,other,delete}-frame`

### DIFF
--- a/moody.el
+++ b/moody.el
@@ -287,6 +287,9 @@ to the command loop."
 (add-hook 'focus-in-hook                    'moody--set-active-window)
 (advice-add 'handle-switch-frame :after     'moody--set-active-window)
 (advice-add 'select-window :after           'moody--set-active-window)
+(advice-add 'make-frame :after              'moody--set-active-window)
+(advice-add 'other-frame :after             'moody--set-active-window)
+(advice-add 'delete-frame :after            'moody--set-active-window)
 
 ;;; _
 (provide 'moody)


### PR DESCRIPTION
This PR fixes the following issue, which might be reproducible on OSX only (I haven't tested on anything else):

- start emacs with moody-based mode line
- create a new frame with `make-frame` (which is bound to Cmd-n for me on OS X)
- now moody has invalid understanding which is the active frame (see screenshot below)
- switch between the 2 frames with `other-frame` (bound to Cmd-` for me on OS X)
- again, moody has invalid understanding which is the active frame
- close one of the frames with `delete-frame` (bound to Cmd-w for me on OS x)
- again, moody has invalid understanding which is the active frame

Maybe there's a cleaner solution to this issue, instead of adding an advice on each of these 3 functions. Please let me know if I can improve the PR.

<img width="1047" alt="screen shot 2018-03-07 at 15 05 15" src="https://user-images.githubusercontent.com/1532071/37093984-fafd7558-2219-11e8-9140-ade5e31dc9d0.png">
