### PR TITLE
Attempt to fix #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ for a few built-in elements.
   that `:underline` and `:overline` are the same color or are
   both `undefined`.  If defined, then the line color should be
   different from the `:background` colors of both `mode-line`
-  and `default`.  Do the same for `mode-line-inactive`.  The
-  line colors of `mode-line` and `mode-line-inactive` do not
-  have to be identical.  For example:
+  and `default`.  The same rules apply to `mode-line-inactive`.
+  The line colors of `mode-line' and `mode-line-inactive` do
+  not necessarily have to be identical.  For example:
 
   ```lisp
   (use-package solarized-theme
@@ -39,8 +39,10 @@ for a few built-in elements.
   ```
 
 * Such replacement functions are defined as commands, making it
-  quicker to try them out.
+  quicker to try them out without having to add anything to your
+  init file.
 
-* To undo a replacement use the optional REVERSE argument of the
-  replacement function.  When calling it interactively, then use
-  a prefix argument to do so.
+* To undo the call to a `moody-replace-*` function, call the same
+  function with `t` as the value of the optional REVERSE argument.
+  You can accomplish the same by interactively calling such a
+  function with a prefix argument to do so.

--- a/moody.el
+++ b/moody.el
@@ -277,8 +277,6 @@ not specified, then faces based on `default', `mode-line' and
 ;;; Active Window
 ;;
 ;; Inspired by, but not identical to, code in `powerline'.
-;; In particular we don't add anything to `focus-out-hook'
-;; because that turned out to be counterproductive.
 
 (defvar moody--active-window (frame-selected-window))
 
@@ -301,6 +299,12 @@ to the command loop."
 (advice-add 'select-window :after           'moody--set-active-window)
 (advice-add 'select-frame :after            'moody--set-active-window)
 (advice-add 'delete-frame :after            'moody--set-active-window)
+
+(defun moody--unset-active-window (&rest _)
+  (setq moody--active-window nil)
+  (force-mode-line-update))
+
+(add-hook 'focus-out-hook 'moody--unset-active-window)
 
 ;;; Kludges
 

--- a/moody.el
+++ b/moody.el
@@ -297,8 +297,6 @@ to the command loop."
 (add-hook 'window-configuration-change-hook 'moody--set-active-window)
 (add-hook 'focus-in-hook                    'moody--set-active-window)
 (advice-add 'select-window :after           'moody--set-active-window)
-(advice-add 'select-frame :after            'moody--set-active-window)
-(advice-add 'delete-frame :after            'moody--set-active-window)
 (advice-add 'handle-switch-frame :after     'moody--set-active-window)
 
 (defun moody--unset-active-window (&rest _)

--- a/moody.el
+++ b/moody.el
@@ -299,6 +299,7 @@ to the command loop."
 (advice-add 'select-window :after           'moody--set-active-window)
 (advice-add 'select-frame :after            'moody--set-active-window)
 (advice-add 'delete-frame :after            'moody--set-active-window)
+(advice-add 'handle-switch-frame :after     'moody--set-active-window)
 
 (defun moody--unset-active-window (&rest _)
   (setq moody--active-window nil)

--- a/moody.el
+++ b/moody.el
@@ -230,7 +230,7 @@ not specified, then faces based on `default', `mode-line' and
 
 ;;;; sml/mode-line-buffer-identification
 
-(defvar sml/mode-line-buffer-identification) ; define in `smart-mode-line.el'
+(defvar sml/mode-line-buffer-identification) ; defined in `smart-mode-line.el'
 
 (defvar moody-sml/mode-line-buffer-identification
   '(:eval (moody-tab

--- a/moody.el
+++ b/moody.el
@@ -44,9 +44,9 @@
 ;;   that `:underline' and `:overline' are the same color or are
 ;;   both `undefined'.  If defined, then the line color should be
 ;;   different from the `:background' colors of both `mode-line'
-;;   and `default'.  Do the same for `mode-line-inactive'.  The
-;;   line colors of `mode-line' and `mode-line-inactive' do not
-;;   have to be identical.  For example:
+;;   and `default'.  The same rules apply to `mode-line-inactive'.
+;;   The line colors of `mode-line' and `mode-line-inactive' do
+;;   not necessarily have to be identical.  For example:
 ;;
 ;;     (use-package solarized-theme
 ;;       :config
@@ -68,11 +68,13 @@
 ;;       (moody-replace-vc-mode))
 
 ;; * Such replacement functions are defines as commands, making it
-;;   quicker to try them out.
+;;   quicker to try them out without having to add anything to your
+;;   init file.
 
-;; * To undo a replacement use the optional REVERSE argument of the
-;;   replacement function.  When calling it interactively, then use
-;;   a prefix argument to do so.
+;; * To undo the call to a `moody-replace-*' function, call the same
+;;   function with t as the value of the optional REVERSE argument.
+;;   You can accomplish the same by interactively calling such a
+;;   function with a prefix argument to do so.
 
 ;;; Code:
 

--- a/moody.el
+++ b/moody.el
@@ -292,7 +292,8 @@ to the command loop."
 (defun moody--set-active-window (&rest _)
   (let ((win (frame-selected-window)))
     (unless (minibuffer-window-active-p win)
-      (setq moody--active-window win))))
+      (setq moody--active-window win)
+      (force-mode-line-update))))
 
 (add-hook 'after-make-frame-functions       'moody--set-active-window)
 (add-hook 'window-configuration-change-hook 'moody--set-active-window)


### PR DESCRIPTION
These for commits in combination or individually may or may not fix #15. I came up with these commits by comparing what `powerline` and `moody` do.

Because the commits might get rearranged or deleted, and new commits might be added, lets number them:

1. moody--set-active-window: Call force-mode-line-update
2. Advice focus-out-hook
3. Advice handle-switch-frame
4. Don't advice select-frame and delete-frame 

I think (1) is most promising and I will try with just that for a while. (2) might also make a difference, but as you can see in the diff, I originally didn't do that because I thought it was counterproductive. I don't think that (3) should make a difference because the code being removed in (4) should have the same effect, but that's from memory, I have not yet studied the involved functions again.

Please try with some or all of these commits applied and let me know what combination fixes the issue for you, if any. Instructions on how to reliably reproduce the issue are also welcome.

There is [more code](https://github.com/milkypostman/powerline/blob/af5ef31a33c3589a9be0b2a55a2741582e605efd/powerline.el#L539-L556) in `powerline` that has no equivalent in `moody`, but I think it is dead code. Windows get pushed to and popped from a stack, but the stack isn't used for anything else as far as I can tell.