### PR TITLE
No lines below /tabs\, use /ribbon/ for vc-mode, add eldoc support using a /tab\

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ for a few built-in elements.
     :config
     (setq x-underline-at-descent-line t)
     (moody-replace-mode-line-buffer-identification)
-    (moody-replace-vc-mode))
+    (moody-replace-vc-mode)
+    (moody-replace-eldoc-minibuffer-message-function))
   ```
 
 * Such replacement functions are defined as commands, making it

--- a/moody.el
+++ b/moody.el
@@ -97,6 +97,21 @@ This should be an even number."
   :type 'function
   :group 'mode-line)
 
+(defcustom moody-ribbon-background '(default :background)
+  "Indirect specification of the background color used for ribbons.
+
+This has the form (FACE ATTRIBUTE), and the color to be used is
+determined using (face-attribute FACE ATTRIBUTE).  If FACE is
+the special value `base', then, depending on whether the window
+is active or not either `mode-line' or `mode-line-inactive' is
+used (or if `moody-wrap's optional arguments FACE-ACTIVE and/or
+FACE-INACTIVE are specified, then those faces).
+
+To get the color used until v0.6.0, then use (base :underline)."
+  :type '(list (symbol  :tag "Face")
+               (keyword :tag "Attribute"))
+  :group 'mode-line)
+
 ;;; Core
 
 (defun moody-replace-element (plain wrapped &optional reverse)
@@ -153,7 +168,9 @@ not specified, then faces based on `default', `mode-line' and
          (line  (if (listp line) (plist-get line :color) line))
          (line  (if (eq line 'unspecified) outer line))
          (inner (if (eq type 'ribbon)
-                    (face-attribute base :underline)
+                    (pcase-let ((`(,face ,attribute) moody-ribbon-background))
+                      (face-attribute (if (eq face 'base) base face)
+                                      attribute))
                   (face-attribute 'default :background)))
          (slant (if (eq direction 'down)
                     (list outer line inner)

--- a/moody.el
+++ b/moody.el
@@ -158,15 +158,13 @@ not specified, then faces based on `default', `mode-line' and
          (slant (if (eq direction 'down)
                     (list outer line inner)
                   (list inner line outer)))
-         (face  (if (eq direction 'down)
-                    (list :overline (and (eq type 'ribbon) line)
-                          :underline line
-                          :background inner)
-                  (list :overline line
-                        :underline (and (or (eq type 'ribbon)
-                                            (not (window-at-side-p nil 'bottom)))
-                                        line)
-                        :background inner)))
+         (face  (list :overline  (and (or (eq direction 'up)
+                                          (eq type 'ribbon))
+                                      line)
+                      :underline (and (or (eq direction 'down)
+                                          (eq type 'ribbon))
+                                      line)
+                      :background inner))
          (pad   (max (- (or width 0) (length string)) 2)))
     (setq string
           (concat (make-string (ceiling pad 2) ?\s)
@@ -265,8 +263,8 @@ not specified, then faces based on `default', `mode-line' and
 ;;;; vc-mode
 
 (defvar moody-vc-mode
-  ;;'(:eval (moody-ribbon (substring vc-mode 1) nil 'up))
-  '(:eval (moody-tab (substring vc-mode 1) nil 'up)))
+  '(:eval (moody-ribbon (substring vc-mode 1) nil 'up)))
+
 (put 'moody-vc-mode 'risky-local-variable t)
 (make-variable-buffer-local 'moody-vc-mode)
 


### PR DESCRIPTION
Stop drawing lines below /tabs\ and stop using /such tabs\ anywhere their use never made sense (vc-mode). That should have been done before but with the removal of the line it has become more important. Use /ribbon/ for vc-mode and, because I found the old look distracting, adjust the default look for all /ribbons/ but allow changing look of individual /ribbons/. Because now there is no element that is using a /tab\ (but also because I wanted to do that for a while anyway) put a /tab\ around eldoc's information when displayed in the mode-line. Because eldoc's mode-line handling is weird, approve upon it. And while we are at it turn moody-replace-* commands into toggles.

It's a bit of a cascade of changes to say the least.

Commit messages provide a bit more reasoning.

The ability to draw a line below /tabs\ is lost and while I implemented experimental support for making this configurable, that goes against the "convention over customization" goal, so I left it out. Lets see if anyone notices and cares enough to bring it up.

Triggered by #33. @memeplex please have a looksy.